### PR TITLE
Add touch gestures for zoom and rotate

### DIFF
--- a/build/deps.js
+++ b/build/deps.js
@@ -177,10 +177,12 @@ var deps = {
 		      'dom/DomEvent.DoubleTap.js',
 		      'dom/DomEvent.Pointer.js',
 		      'core/Handler.js',
+		      'map/handler/Map.TouchGestures.js',
 		      'map/handler/Map.TouchZoom.js',
+		      'map/handler/Map.TouchRotate.js',
 		      'map/handler/Map.Tap.js'],
 		deps: ['AnimationZoom'],
-		desc: 'Enables smooth touch zoom / tap / longhold / doubletap on iOS, IE10, Android.'
+		desc: 'Enables smooth touch zoom / tap / rotate / longhold / doubletap on iOS, IE10, Android.'
 	},
 
 	BoxZoom: {

--- a/src/map/handler/Map.TouchGestures.js
+++ b/src/map/handler/Map.TouchGestures.js
@@ -1,0 +1,165 @@
+/*
+ * L.Handler.TouchGestures is both TouchZoom plus TouchRotate.
+ */
+
+// @namespace Map
+// @section Interaction Options
+L.Map.mergeOptions({
+	// @option bounceAtZoomLimits: Boolean = true
+	// Set it to false if you don't want the map to zoom beyond min/max zoom
+	// and then bounce back when pinch-zooming.
+	bounceAtZoomLimits: true
+});
+
+L.Map.TouchGestures = L.Handler.extend({
+
+	initialize: function (map) {
+		this._map = map;
+		this.rotate = !!this._map.options.touchRotate;
+		this.zoom = !!this._map.options.touchZoom;
+	},
+
+	addHooks: function () {
+		L.DomEvent.on(this._map._container, 'touchstart', this._onTouchStart, this);
+	},
+
+	removeHooks: function () {
+		L.DomEvent.off(this._map._container, 'touchstart', this._onTouchStart, this);
+	},
+
+	_onTouchStart: function (e) {
+		var map = this._map;
+
+		if (!e.touches || e.touches.length !== 2 || map._animatingZoom || this._zooming || this._rotating) { return; }
+
+		var p1 = map.mouseEventToContainerPoint(e.touches[0]),
+		    p2 = map.mouseEventToContainerPoint(e.touches[1]),
+		    vector = p1.subtract(p2);
+
+		this._centerPoint = map.getSize()._divideBy(2);
+		this._startLatLng = map.containerPointToLatLng(this._centerPoint);
+
+		if (this.zoom) {
+			if (map.options.touchZoom !== 'center') {
+				this._pinchStartLatLng = map.containerPointToLatLng(p1.add(p2)._divideBy(2));
+			}
+			this._startDist = p1.distanceTo(p2);
+			this._startZoom = map.getZoom();
+			this._zooming = true;
+		} else {
+			this._zooming = false;
+		}
+
+		if (this.rotate) {
+			this._startTheta = Math.atan(vector.x / vector.y);
+			this._startBearing = map.getBearing();
+			if (vector.y < 0) { this._startBearing += 180; }
+			this._rotating = true;
+		} else {
+			this._rotating = false;
+		}
+		this._rotated = false;
+
+		this._moved = false;
+
+		map.stop();
+
+		L.DomEvent
+		    .on(document, 'touchmove', this._onTouchMove, this)
+		    .on(document, 'touchend', this._onTouchEnd, this);
+
+		L.DomEvent.preventDefault(e);
+	},
+
+	_onTouchMove: function (e) {
+		if (!e.touches || e.touches.length !== 2 || !(this._zooming || this._rotating)) { return; }
+
+		var map = this._map,
+		    p1 = map.mouseEventToContainerPoint(e.touches[0]),
+		    p2 = map.mouseEventToContainerPoint(e.touches[1]),
+		    vector = p1.subtract(p2),
+		    scale = p1.distanceTo(p2) / this._startDist,
+		    delta;
+
+		if (this._rotating) {
+			var theta = Math.atan(vector.x / vector.y);
+			var bearingDelta = (theta - this._startTheta) * L.DomUtil.RAD_TO_DEG;
+			if (vector.y < 0) { bearingDelta += 180; }
+			if (bearingDelta) {
+				/// TODO: The pivot should be the last touch point, but zoomAnimation manages to
+				///   overwrite the rotate pane position. Maybe related to #3529.
+				map.setBearing(this._startBearing - bearingDelta, true);
+				this._rotated = true;
+			}
+		}
+
+		if (this._zooming) {
+			this._zoom = map.getScaleZoom(scale, this._startZoom);
+
+			if (!map.options.bounceAtZoomLimits && (
+				(this._zoom < map.getMinZoom() && scale < 1) ||
+				(this._zoom > map.getMaxZoom() && scale > 1))) {
+				this._zoom = map._limitZoom(this._zoom);
+			}
+
+			if (map.options.touchZoom === 'center') {
+				this._center = this._startLatLng;
+				if (scale === 1) { return; }
+			} else {
+				// Get delta from pinch to center, so centerLatLng is delta applied to initial pinchLatLng
+				delta = p1._add(p2)._divideBy(2)._subtract(this._centerPoint);
+				if (scale === 1 && delta.x === 0 && delta.y === 0) { return; }
+
+				var alpha = -map.getBearing() * L.DomUtil.DEG_TO_RAD;
+
+				this._center = map.unproject(map.project(this._pinchStartLatLng).subtract(delta.rotate(alpha)));
+			}
+
+		}
+
+		if (!this._moved) {
+			map._moveStart(true);
+			this._moved = true;
+		}
+
+		L.Util.cancelAnimFrame(this._animRequest);
+
+		var moveFn = L.bind(map._move, map, this._center, this._zoom, {pinch: true, round: false});
+		this._animRequest = L.Util.requestAnimFrame(moveFn, this, true);
+
+		L.DomEvent.preventDefault(e);
+	},
+
+	_onTouchEnd: function () {
+		if (!this._moved || !this._zooming) {
+			this._zooming = false;
+			return;
+		}
+
+		this._zooming = false;
+		this._rotating = false;
+		L.Util.cancelAnimFrame(this._animRequest);
+
+		L.DomEvent
+		    .off(document, 'touchmove', this._onTouchMove)
+		    .off(document, 'touchend', this._onTouchEnd);
+
+		if (this.zoom) {
+			// Pinch updates GridLayers' levels only when snapZoom is off, so snapZoom becomes noUpdate.
+			if (this._map.options.zoomAnimation) {
+				this._map._animateZoom(this._center, this._map._limitZoom(this._zoom), true, this._map.options.snapZoom);
+			} else {
+				this._map._resetView(this._center, this._map._limitZoom(this._zoom));
+			}
+		}
+
+		if (this.rotate && this._rotated) {
+			this._map.setBearing(this._map.getBearing());
+		}
+	}
+});
+
+// @section Handlers
+// @property touchGestures: Handler
+// Touch gestures handler.
+L.Map.addInitHook('addHandler', 'touchGestures', L.Map.TouchGestures);

--- a/src/map/handler/Map.TouchGestures.js
+++ b/src/map/handler/Map.TouchGestures.js
@@ -58,7 +58,6 @@ L.Map.TouchGestures = L.Handler.extend({
 		} else {
 			this._rotating = false;
 		}
-		this._rotated = false;
 
 		this._moved = false;
 
@@ -89,7 +88,6 @@ L.Map.TouchGestures = L.Handler.extend({
 				/// TODO: The pivot should be the last touch point, but zoomAnimation manages to
 				///   overwrite the rotate pane position. Maybe related to #3529.
 				map.setBearing(this._startBearing - bearingDelta);
-				this._rotated = true;
 			}
 		}
 
@@ -151,10 +149,6 @@ L.Map.TouchGestures = L.Handler.extend({
 			} else {
 				this._map._resetView(this._center, this._map._limitZoom(this._zoom));
 			}
-		}
-
-		if (this.rotate && this._rotated) {
-			this._map.setBearing(this._map.getBearing());
 		}
 	}
 });

--- a/src/map/handler/Map.TouchGestures.js
+++ b/src/map/handler/Map.TouchGestures.js
@@ -88,7 +88,7 @@ L.Map.TouchGestures = L.Handler.extend({
 			if (bearingDelta) {
 				/// TODO: The pivot should be the last touch point, but zoomAnimation manages to
 				///   overwrite the rotate pane position. Maybe related to #3529.
-				map.setBearing(this._startBearing - bearingDelta, true);
+				map.setBearing(this._startBearing - bearingDelta);
 				this._rotated = true;
 			}
 		}

--- a/src/map/handler/Map.TouchRotate.js
+++ b/src/map/handler/Map.TouchRotate.js
@@ -8,7 +8,7 @@ L.Map.mergeOptions({
 	// @section Touch interaction options
 	// @option touchRotate: Boolean|String = *
 	// Whether the map can be rotated with a two-finger rotation gesture
-	touchRotate: L.Browser.touch && !L.Browser.android23
+	touchRotate: false
 });
 
 L.Map.TouchRotate = L.Handler.extend({

--- a/src/map/handler/Map.TouchRotate.js
+++ b/src/map/handler/Map.TouchRotate.js
@@ -1,0 +1,28 @@
+/*
+ * L.Handler.TouchRotate is used by L.Map to add two-finger rotation gestures.
+ */
+
+// @namespace Map
+// @section Interaction Options
+L.Map.mergeOptions({
+	// @section Touch interaction options
+	// @option touchRotate: Boolean|String = *
+	// Whether the map can be rotated with a two-finger rotation gesture
+	touchRotate: L.Browser.touch && !L.Browser.android23
+});
+
+L.Map.TouchRotate = L.Handler.extend({
+	addHooks: function () {
+		this._map.touchGestures.enable();
+		this._map.touchGestures.rotate = true;
+	},
+
+	removeHooks: function () {
+		this._map.touchGestures.rotate = false;
+	}
+});
+
+// @section Handlers
+// @property touchZoom: Handler
+// Touch rotate handler.
+L.Map.addInitHook('addHandler', 'touchRotate', L.Map.TouchRotate);

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -12,111 +12,18 @@ L.Map.mergeOptions({
 	// where the touch events (fingers) were. Enabled for touch-capable web
 	// browsers except for old Androids.
 	touchZoom: L.Browser.touch && !L.Browser.android23,
-
-	// @option bounceAtZoomLimits: Boolean = true
-	// Set it to false if you don't want the map to zoom beyond min/max zoom
-	// and then bounce back when pinch-zooming.
-	bounceAtZoomLimits: true
 });
 
 L.Map.TouchZoom = L.Handler.extend({
 	addHooks: function () {
 		L.DomUtil.addClass(this._map._container, 'leaflet-touch-zoom');
-		L.DomEvent.on(this._map._container, 'touchstart', this._onTouchStart, this);
+		this._map.touchGestures.enable();
+		this._map.touchGestures.zoom = true;
 	},
 
 	removeHooks: function () {
 		L.DomUtil.removeClass(this._map._container, 'leaflet-touch-zoom');
-		L.DomEvent.off(this._map._container, 'touchstart', this._onTouchStart, this);
-	},
-
-	_onTouchStart: function (e) {
-		var map = this._map;
-		if (!e.touches || e.touches.length !== 2 || map._animatingZoom || this._zooming) { return; }
-
-		var p1 = map.mouseEventToContainerPoint(e.touches[0]),
-		    p2 = map.mouseEventToContainerPoint(e.touches[1]);
-
-		this._centerPoint = map.getSize()._divideBy(2);
-		this._startLatLng = map.containerPointToLatLng(this._centerPoint);
-		if (map.options.touchZoom !== 'center') {
-			this._pinchStartLatLng = map.containerPointToLatLng(p1.add(p2)._divideBy(2));
-		}
-
-		this._startDist = p1.distanceTo(p2);
-		this._startZoom = map.getZoom();
-
-		this._moved = false;
-		this._zooming = true;
-
-		map._stop();
-
-		L.DomEvent
-		    .on(document, 'touchmove', this._onTouchMove, this)
-		    .on(document, 'touchend', this._onTouchEnd, this);
-
-		L.DomEvent.preventDefault(e);
-	},
-
-	_onTouchMove: function (e) {
-		if (!e.touches || e.touches.length !== 2 || !this._zooming) { return; }
-
-		var map = this._map,
-		    p1 = map.mouseEventToContainerPoint(e.touches[0]),
-		    p2 = map.mouseEventToContainerPoint(e.touches[1]),
-		    scale = p1.distanceTo(p2) / this._startDist;
-
-
-		this._zoom = map.getScaleZoom(scale, this._startZoom);
-
-		if (!map.options.bounceAtZoomLimits && (
-			(this._zoom < map.getMinZoom() && scale < 1) ||
-			(this._zoom > map.getMaxZoom() && scale > 1))) {
-			this._zoom = map._limitZoom(this._zoom);
-		}
-
-		if (map.options.touchZoom === 'center') {
-			this._center = this._startLatLng;
-			if (scale === 1) { return; }
-		} else {
-			// Get delta from pinch to center, so centerLatLng is delta applied to initial pinchLatLng
-			var delta = p1._add(p2)._divideBy(2)._subtract(this._centerPoint);
-			if (scale === 1 && delta.x === 0 && delta.y === 0) { return; }
-			this._center = map.unproject(map.project(this._pinchStartLatLng, this._zoom).subtract(delta), this._zoom);
-		}
-
-		if (!this._moved) {
-			map._moveStart(true);
-			this._moved = true;
-		}
-
-		L.Util.cancelAnimFrame(this._animRequest);
-
-		var moveFn = L.bind(map._move, map, this._center, this._zoom, {pinch: true, round: false});
-		this._animRequest = L.Util.requestAnimFrame(moveFn, this, true);
-
-		L.DomEvent.preventDefault(e);
-	},
-
-	_onTouchEnd: function () {
-		if (!this._moved || !this._zooming) {
-			this._zooming = false;
-			return;
-		}
-
-		this._zooming = false;
-		L.Util.cancelAnimFrame(this._animRequest);
-
-		L.DomEvent
-		    .off(document, 'touchmove', this._onTouchMove)
-		    .off(document, 'touchend', this._onTouchEnd);
-
-		// Pinch updates GridLayers' levels only when snapZoom is off, so snapZoom becomes noUpdate.
-		if (this._map.options.zoomAnimation) {
-			this._map._animateZoom(this._center, this._map._limitZoom(this._zoom), true, this._map.options.snapZoom);
-		} else {
-			this._map._resetView(this._center, this._map._limitZoom(this._zoom));
-		}
+		this._map.touchGestures.zoom = false;
 	}
 });
 


### PR DESCRIPTION
Touch-zoom and touch-rotate gestures. The "touchRotate" option is now disabled by default, instead of the option being set depending on the touch-capabilities of the device.

Can be merged now, but currently touch-zoom is broken in rotate-rc1  because of https://github.com/Leaflet/Leaflet/issues/4702, so if you try this PR, you will also see the same bug. Anyway, this PR can be merged, and then when the fix for 4702 is done in leaflet, merge it back to this rotate-rc1

Cleaner PR and less buggy than https://github.com/hyperknot/Leaflet/pull/16

Should be squashed in one commit!

Fixes Backport touch gestures and merge in this branch https://github.com/hyperknot/Leaflet/issues/6